### PR TITLE
chore: improve configs required for successful release

### DIFF
--- a/.github/configs/.prettierignore
+++ b/.github/configs/.prettierignore
@@ -1,4 +1,0 @@
-# `release-please` doesn't generate prettier compliant output, see relevant issues:
-# https://github.com/googleapis/release-please/issues/1902
-# https://github.com/googleapis/release-please/issues/1802
-CHANGELOG.md

--- a/.github/configs/.prettierignore
+++ b/.github/configs/.prettierignore
@@ -1,0 +1,4 @@
+# `release-please` doesn't generate prettier compliant output, see relevant issues:
+# https://github.com/googleapis/release-please/issues/1902
+# https://github.com/googleapis/release-please/issues/1802
+CHANGELOG.md

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # required for label creation
 
 jobs:
   release-please:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,9 +36,9 @@ lint:
       paths:
         - "**/backend.tf.json"
     # Ignore CHANGELOG.md as release-please manages this file
-    - linters: [prettier, markdownlint]
+    - linters: [ALL]
       paths:
-        - CHANGELOG.md
+        - "**/CHANGELOG.md"
 actions:
   enabled:
     - terraform-docs


### PR DESCRIPTION
## what

- Update release-please permissions to fix actions error:
> release-please failed: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
- Ignore CHANGELOG to avoid extra releases.

## why

- release-please is not happy
- We got an extra release PR: https://github.com/masterpointio/terraform-github-teams/pull/4

## references

- https://github.com/googleapis/release-please-action/issues/1105
- https://github.com/masterpointio/terraform-github-teams/actions/runs/14594795458


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to allow issue label modifications.
  - Expanded lint ignore settings to exclude all linters for any CHANGELOG.md file throughout the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->